### PR TITLE
don't reset tip position when hiding

### DIFF
--- a/src/d3-tip.js
+++ b/src/d3-tip.js
@@ -71,8 +71,6 @@ export default function () {
     tip.hide = function () {
         var nodel = getNodeEl()
         nodel
-            .style('top', 0)
-            .style('left', 0)
             .style('opacity', 0)
             .style('pointer-events', 'none')
         return tip
@@ -339,9 +337,3 @@ export default function () {
 
     return tip
 };
-
-
-
-
-
-


### PR DESCRIPTION
Fixes #2.

Resetting the position of the tooltip to `0, 0` when hiding was causing some flickering when a transition effect is applied to the opacity of the tooltip (see #2 discussion).
This PR simply removes that behaviour.

Changing the tooltip style/position after hiding should still be achievable programmatically, using the `tip.style()` function, when handling the event that triggers the hiding (e.g. `mouseout`). If more sophisticated behaviour was required we could always extend the tooltip API.